### PR TITLE
Reduce package size via `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "repository": "ybiquitous/remark-lint-code-block-syntax",
   "main": "index.js",
+  "files": [],
   "scripts": {
     "test": "jest",
     "lint": "npx eslint . && npx prettier --check .",


### PR DESCRIPTION
`npm pack` change:

```
npm notice 1.1kB LICENSE
npm notice 565B  README.md
npm notice 307B  .editorconfig
npm notice 183B  .eslintrc.js
npm notice 199B  .github/dependabot.yml
npm notice 272B  .github/workflows/lint.yml
npm notice 438B  .github/workflows/publish.yml
npm notice 384B  .github/workflows/test.yml
npm notice 1.5kB index.js
npm notice 1.7kB index.test.js
npm notice 738B  package.json
```

↓

```
npm notice 1.1kB LICENSE
npm notice 565B  README.md
npm notice 1.5kB index.js
npm notice 753B  package.json
```