### PR TITLE
Support newer syntax for JS instead of ES2022

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function codeSyntax(tree, file) {
     try {
       swc.parseSync(code, {
         syntax: "ecmascript",
-        target: "es2022",
+        target: "esnext",
       });
       return null;
     } catch (e) {


### PR DESCRIPTION
This changes the `target` option for SWC parser.
