### PR TITLE
Support JSONC

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A [remark-lint](https://github.com/remarkjs/remark-lint) rule to check language 
 
 - JavaScript
 - JSON
+- JSONC
 - YAML
 - CSS
 

--- a/index.test.js
+++ b/index.test.js
@@ -38,6 +38,25 @@ describe("JSON", () => {
   });
 });
 
+describe("JSONC", () => {
+  test("valid", () => {
+    assert.deepEqual(run("jsonc", "{} // comment"), []);
+  });
+
+  test("invalid", () => {
+    assert.deepEqual(run("jsonc", "{[\n}}"), [
+      {
+        column: 1,
+        line: 1,
+        message:
+          "Invalid JSONC: PropertyNameExpected (1:2), ValueExpected (2:1), EndOfFileExpected (2:2)",
+        ruleId: "code-block-syntax",
+        source: "remark-lint",
+      },
+    ]);
+  });
+});
+
 describe("JavaScript", () => {
   test("valid", () => {
     assert.deepEqual(run("js", "let a=1"), []);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@swc/core": "^1.7.22",
         "js-yaml": "^4.1.0",
+        "jsonc-parser": "^3.3.1",
         "postcss": "^8.4.43",
         "unified-lint-rule": "^3.0.0",
         "unist-util-visit": "^5.0.0"
@@ -1024,6 +1025,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2784,6 +2791,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@swc/core": "^1.7.22",
     "js-yaml": "^4.1.0",
+    "jsonc-parser": "^3.3.1",
     "postcss": "^8.4.43",
     "unified-lint-rule": "^3.0.0",
     "unist-util-visit": "^5.0.0"


### PR DESCRIPTION
Thanks to [jsonc-parser](https://www.npmjs.com/package/jsonc-parser).

Reasons to choose it:
- No dependencies
- Popular (7M downloads weekly)
- Maintained by Microsoft
